### PR TITLE
Implement Schnorr signatures

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
   },
   "homepage": "https://github.com/CodeChain-io/codechain-primitives-js#readme",
   "devDependencies": {
+    "@types/bn.js": "^4.11.2",
     "@types/jest": "^23.3.2",
     "@types/lodash": "^4.14.116",
     "@types/node": "^10.10.0",
+    "@types/node-forge": "^0.7.5",
     "jest": "^23.6.0",
     "prettier": "1.14.2",
     "ts-jest": "^23.1.4",
@@ -47,10 +49,12 @@
   "dependencies": {
     "bignumber.js": "^7.2.1",
     "blakejs": "^1.1.0",
+    "bn.js": "^4.11.8",
     "buffer": "^5.2.1",
     "elliptic": "^6.4.1",
     "lodash": "^4.17.11",
     "ripemd160": "^2.0.2",
-    "rlp": "^2.1.0"
+    "rlp": "^2.1.0",
+    "node-forge": "^0.7.6"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,14 +18,21 @@ export {
     ripemd160
 } from "./hash";
 
+export { generatePrivateKey, getPublicFromPrivate } from "./key/key";
+
 export {
     EcdsaSignature,
     signEcdsa,
     verifyEcdsa,
-    recoverEcdsa,
-    generatePrivateKey,
-    getPublicFromPrivate
-} from "./key";
+    recoverEcdsa
+} from "./key/ecdsa";
+
+export {
+    SchnorrSignature,
+    signSchnorr,
+    verifySchnorr,
+    recoverSchnorr
+} from "./key/schnorr";
 
 export {
     toHex,

--- a/src/key/ecdsa.ts
+++ b/src/key/ecdsa.ts
@@ -1,5 +1,3 @@
-import * as _ from "lodash";
-
 /**
  * @hidden
  */
@@ -16,7 +14,7 @@ export interface EcdsaSignature {
 }
 
 /**
- * Gets signature for message from private key.
+ * Gets ECDSA signature for message from private key.
  * @param message arbitrary length string
  * @param priv 32 byte hexadecimal string of private key
  * @returns r, s, v of ECDSA signature
@@ -48,7 +46,7 @@ export const verifyEcdsa = (
 };
 
 /**
- * Gets public key from the message and signature.
+ * Gets public key from the message and ECDSA signature.
  * @param message arbitrary length string
  * @param signature r, s, v of ECDSA signature
  * @returns 64 byte hexadecimal string public key
@@ -66,28 +64,6 @@ export const recoverEcdsa = (
             signature,
             signature.v
         )
-        .encode("hex")
-        .slice(2);
-};
-
-/**
- * Generates a private key.
- * @returns 32 byte hexadecimal string of private key
- */
-export const generatePrivateKey = (): string => {
-    return _.padStart(secp256k1.genKeyPair().priv.toString("hex"), 64, "0");
-};
-
-/**
- * Gets public key from private key.
- * @param priv 32 byte hexadecimal string of private key
- * @returns 64 byte hexadecimal string of public key
- */
-export const getPublicFromPrivate = (priv: string): string => {
-    const key = secp256k1.keyFromPrivate(priv);
-    // Remove prefix "04" which represents it's uncompressed form.
-    return key
-        .getPublic()
         .encode("hex")
         .slice(2);
 };

--- a/src/key/key.ts
+++ b/src/key/key.ts
@@ -1,0 +1,32 @@
+import * as _ from "lodash";
+
+/**
+ * @hidden
+ */
+const EC = require("elliptic").ec;
+/**
+ * @hidden
+ */
+const secp256k1 = new EC("secp256k1");
+
+/**
+ * Generates a private key.
+ * @returns 32 byte hexadecimal string of private key
+ */
+export const generatePrivateKey = (): string => {
+    return _.padStart(secp256k1.genKeyPair().priv.toString("hex"), 64, "0");
+};
+
+/**
+ * Gets public key from private key.
+ * @param priv 32 byte hexadecimal string of private key
+ * @returns 64 byte hexadecimal string of public key
+ */
+export const getPublicFromPrivate = (priv: string): string => {
+    const key = secp256k1.keyFromPrivate(priv);
+    // Remove prefix "04" which represents it's uncompressed form.
+    return key
+        .getPublic()
+        .encode("hex")
+        .slice(2);
+};

--- a/src/key/schnorr.ts
+++ b/src/key/schnorr.ts
@@ -1,0 +1,141 @@
+import BN = require("bn.js");
+import { md } from "node-forge";
+
+/**
+ * @hidden
+ */
+const EC = require("elliptic").ec;
+/**
+ * @hidden
+ */
+const secp256k1 = new EC("secp256k1");
+
+export interface SchnorrSignature {
+    r: string;
+    s: string;
+}
+
+/**
+ * @hidden
+ */
+function schnorrHash(r: any, message: string): string {
+    const rString = r.toBuffer("ge", 32).toString("binary");
+    const sha256 = md.sha256.create();
+    sha256.update(rString).update(message);
+    return sha256.digest().toHex();
+}
+
+/**
+ * Gets Schnorr signature for message from private key.
+ * @param message arbitrary length string
+ * @param priv 32 byte hexadecimal string of private key
+ * @returns r, s of Schnorr signature
+ */
+export const signSchnorr = (
+    message: string,
+    priv: string
+): SchnorrSignature => {
+    while (true) {
+        const nonceKey = secp256k1.genKeyPair();
+        const R = nonceKey.getPublic();
+        const r = R.x;
+        let k = nonceKey.priv;
+        if (R.y.isOdd()) {
+            k = k.neg().umod(secp256k1.n);
+        }
+
+        const hashString = schnorrHash(r, message);
+        const h = new BN(hashString, 16);
+        if (h.isZero() || h.gte(secp256k1.n)) {
+            continue;
+        }
+
+        const privN = new BN(priv, 16);
+        const s = k.sub(privN.mul(h).umod(secp256k1.n)).umod(secp256k1.n);
+        return {
+            r: r.toString("hex"),
+            s: s.toString("hex")
+        };
+    }
+};
+
+/**
+ * Checks if the signature from signSchnorr is correct.
+ * @param message arbitrary length string
+ * @param signature r, s of Schnorr signature
+ * @param pub 64 byte hexadecimal string of public key
+ * @returns if signature is valid, true. Else false.
+ */
+export const verifySchnorr = (
+    message: string,
+    signature: SchnorrSignature,
+    pub: string
+): boolean => {
+    const key = secp256k1.keyFromPublic("04" + pub, "hex");
+    if (!key.validate().result) {
+        return false;
+    }
+
+    const r = new BN(signature.r, 16);
+    const s = new BN(signature.s, 16);
+    if (s.gte(secp256k1.n)) {
+        return false;
+    }
+
+    const hashString = schnorrHash(r, message);
+    const h = new BN(hashString, 16);
+    if (h.isZero() || h.gte(secp256k1.n)) {
+        return false;
+    }
+
+    const Rv = secp256k1.g.mulAdd(s, key.getPublic(), h);
+    if (Rv.y.isOdd() || Rv.isInfinity()) {
+        return false;
+    }
+
+    return Rv.x.eq(r);
+};
+
+/**
+ * Gets public key from the message and Schnorr signature.
+ * @param message arbitrary length string
+ * @param signature r, s of Schnorr signature
+ * @returns 64 byte hexadecimal string public key
+ */
+export const recoverSchnorr = (
+    message: string,
+    signature: SchnorrSignature
+): string => {
+    const r = new BN(signature.r, 16);
+    const s = new BN(signature.s, 16);
+    if (s.gte(secp256k1.n)) {
+        throw new Error("invalid s value");
+    }
+
+    const hashString = schnorrHash(r, message);
+    const h = new BN(hashString, 16);
+    if (h.isZero() || h.gte(secp256k1.n)) {
+        throw new Error("invalid hash value");
+    }
+
+    const hInv = h.invm(secp256k1.n);
+    const k = s
+        .neg()
+        .umod(secp256k1.n)
+        .mul(hInv)
+        .umod(secp256k1.n);
+    try {
+        const R = secp256k1.curve.pointFromX(r, 0);
+        const pubkey = secp256k1.g.mulAdd(k, R, hInv);
+        if (pubkey.isInfinity()) {
+            throw new Error("recovered public key value is infinity");
+        }
+        return pubkey.encode("hex").slice(2);
+    } catch (e) {
+        if (e.message === "invalid point") {
+            throw new Error("invalid r value");
+        } else {
+            throw e;
+        }
+    }
+};

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,5 +1,5 @@
 import { blake160 } from "./hash";
-import { getPublicFromPrivate } from "./key";
+import { getPublicFromPrivate } from "./key/key";
 
 /**
  * @hidden

--- a/test/key.test.ts
+++ b/test/key.test.ts
@@ -2,6 +2,10 @@ import {
     signEcdsa,
     verifyEcdsa,
     recoverEcdsa,
+    SchnorrSignature,
+    signSchnorr,
+    verifySchnorr,
+    recoverSchnorr,
     generatePrivateKey,
     getPublicFromPrivate
 } from "..";
@@ -31,4 +35,63 @@ test("sign & recover ECDSA", () => {
     const pub = getPublicFromPrivate(priv);
     const sig = signEcdsa(msg, priv);
     expect(recoverEcdsa(msg, sig)).toBe(pub);
+});
+
+// Examples are generated from libsecp256k1
+describe.each([
+    [
+        "2730417b940503dfc8dddfe5dfdbfc029b269fec9bc0170a156bcfe30f5afda8",
+        "c61e7bde9bb280bc0ea1d29dd868f34c97a93feda56d174338775a6a4fcb3cff",
+        "2a7c03d513c820c6cee1cc4a7c00d350d8ee6bb8a032615af040e0930c0d2ac8cea327ff6f044cee1499ac04e1b4b0406eacd1f606cbeec5c2535562f25f05f1"
+    ],
+    [
+        "52d9ec33be855d9f27e1459dabf195266e1c4ca2bd1f44bbc7c6c0c2ebd0b280",
+        "f61dbea29a861e0ff61f209f8824a4deadec80cad4d7b6cf3672c4140d82349d",
+        "42236cd3b8e8a24d4a4db3eabf059d2f977c04d4ff6422cc5b99e9bcc913fd83f1d39993b651c420990d696ce8aac7c2bcc89a41b45dbe7241bbda50ca2be92a"
+    ],
+    [
+        "44fd4a087cbf2a0ef6762cd7de0f3020fd71b11f13afa014741dcf3f098e1de1",
+        "7e1ac454dd8b2068d15020f16680ab22ac94ea38d0e2dc006fa2bdf9f200112b",
+        "9858a21134e15a0b04e21aaa6391bfb8e94de18497810ae24d88920e2cf45e9bd681235551493d9e3f740086e8be5ba19c763f7b27536fc75e159e2dc08763dd"
+    ],
+    [
+        "3d52843f74e47b24edd77fcf0b2041ba1b57984eb20a4a17144c08c9588d2a0a",
+        "0d0ee35bec4b04d8c97b23357d66ead5d1486bdfcad56949c4c69291af532276",
+        "b4c29459031b740da8a20d75a948344c908ff576bcc16e50f1d1af335c321923a6416a13c152cc1e0fbb30bd568e033f919b4e548fc79996bc7c5e1a68f5dd48"
+    ],
+    [
+        "99a819048cc03500e0ad3debeb9beace8e26e5960f7045a551fa5c14247b8805",
+        "353d8f4a3d139a57bdf9b1c3a836f3a380fe8ba558356cd344766c97990b923b",
+        "74cb307814a2f43ed0974dc278d6fc42f04c9d682e2df6a4a449bf628c4a3a03bbf6558b4c4a8e4148322cff3b2ce11eb96b0a9c76395054550ba307eed98573"
+    ]
+])("verify & recover Schnorr with example: %p", (msgStr, priv, sigStr) => {
+    const msg = new Buffer(msgStr, "hex").toString("binary");
+    const sig: SchnorrSignature = {
+        r: sigStr.substr(0, 64),
+        s: sigStr.substr(64, 64)
+    };
+    const pub = getPublicFromPrivate(priv);
+
+    test("verify", () => {
+        expect(verifySchnorr(msg, sig, pub)).toBe(true);
+    });
+    test("recover", () => {
+        expect(recoverSchnorr(msg, sig)).toBe(pub);
+    });
+});
+
+test("sign & verify Schnorr", () => {
+    const msg = "CodeChain";
+    const priv = generatePrivateKey();
+    const pub = getPublicFromPrivate(priv);
+    const sig = signSchnorr(msg, priv);
+    expect(verifySchnorr(msg, sig, pub)).toBe(true);
+});
+
+test("sign & recover Schnorr", () => {
+    const msg = "CodeChain";
+    const priv = generatePrivateKey();
+    const pub = getPublicFromPrivate(priv);
+    const sig = signSchnorr(msg, priv);
+    expect(recoverSchnorr(msg, sig)).toBe(pub);
 });


### PR DESCRIPTION
From #25. 
## To-do
- [x] ~~Compatible with libsecp256k1~~
  - Locally tested, and will be tested after adding on the SDK.
- [x] ~~Change bignumber.js to bn.js~~
  - Hard to change `U256` to use bn.js without changing the spec
- [x] Check how to assert limitations