### PR TITLE
Check input validity in the signature functions

### DIFF
--- a/src/key/ecdsa.ts
+++ b/src/key/ecdsa.ts
@@ -20,6 +20,12 @@ export interface EcdsaSignature {
  * @returns r, s, v of ECDSA signature
  */
 export const signEcdsa = (message: string, priv: string): EcdsaSignature => {
+    if (!/^[0-9a-fA-F]{64}$/.test(message)) {
+        throw new Error(`invalid message: ${message}`);
+    }
+    if (!/^[0-9a-fA-F]{64}$/.test(priv)) {
+        throw new Error(`invalid private key: ${priv}`);
+    }
     const key = secp256k1.keyFromPrivate(priv);
     const { r, s, recoveryParam: v } = key.sign(message, { canonical: true });
     return {
@@ -41,6 +47,20 @@ export const verifyEcdsa = (
     signature: EcdsaSignature,
     pub: string
 ): boolean => {
+    if (!/^[0-9a-fA-F]{64}$/.test(message)) {
+        throw new Error(`invalid message: ${message}`);
+    }
+    if (
+        !/^[0-9a-fA-F]{1,64}$/.test(signature.r) ||
+        !/^[0-9a-fA-F]{1,64}$/.test(signature.s) ||
+        signature.v < 0 ||
+        signature.v > 3
+    ) {
+        throw new Error(`invalid signature: ${signature}`);
+    }
+    if (!/^[0-9a-fA-F]{128}$/.test(pub)) {
+        throw new Error(`invalid public key: ${pub}`);
+    }
     const key = secp256k1.keyFromPublic("04" + pub, "hex");
     return key.verify(message, signature);
 };
@@ -55,6 +75,17 @@ export const recoverEcdsa = (
     message: string,
     signature: EcdsaSignature
 ): string => {
+    if (!/^[0-9a-fA-F]{64}$/.test(message)) {
+        throw new Error(`invalid message: ${message}`);
+    }
+    if (
+        !/^[0-9a-fA-F]{1,64}$/.test(signature.r) ||
+        !/^[0-9a-fA-F]{1,64}$/.test(signature.s) ||
+        signature.v < 0 ||
+        signature.v > 3
+    ) {
+        throw new Error(`invalid signature: ${signature}`);
+    }
     return secp256k1
         .recoverPubKey(
             secp256k1

--- a/src/key/ecdsa.ts
+++ b/src/key/ecdsa.ts
@@ -15,7 +15,7 @@ export interface EcdsaSignature {
 
 /**
  * Gets ECDSA signature for message from private key.
- * @param message arbitrary length string
+ * @param message 32 byte hexademical string
  * @param priv 32 byte hexadecimal string of private key
  * @returns r, s, v of ECDSA signature
  */
@@ -31,7 +31,7 @@ export const signEcdsa = (message: string, priv: string): EcdsaSignature => {
 
 /**
  * Checks if the signature from signEcdsa is correct.
- * @param message arbitrary length string
+ * @param message 32 byte hexademical string
  * @param signature r, s, v of ECDSA signature
  * @param pub 64 byte hexadecimal string of public key
  * @returns if signature is valid, true. Else false.
@@ -47,7 +47,7 @@ export const verifyEcdsa = (
 
 /**
  * Gets public key from the message and ECDSA signature.
- * @param message arbitrary length string
+ * @param message 32 byte hexademical string
  * @param signature r, s, v of ECDSA signature
  * @returns 64 byte hexadecimal string public key
  */

--- a/src/key/schnorr.ts
+++ b/src/key/schnorr.ts
@@ -36,6 +36,12 @@ export const signSchnorr = (
     message: string,
     priv: string
 ): SchnorrSignature => {
+    if (!/^[0-9a-fA-F]{64}$/.test(message)) {
+        throw new Error(`invalid message: ${message}`);
+    }
+    if (!/^[0-9a-fA-F]{64}$/.test(priv)) {
+        throw new Error(`invalid private key: ${priv}`);
+    }
     const msg = new BN(message, 16);
     const privN = new BN(priv, 16);
     while (true) {
@@ -73,6 +79,18 @@ export const verifySchnorr = (
     signature: SchnorrSignature,
     pub: string
 ): boolean => {
+    if (!/^[0-9a-fA-F]{64}$/.test(message)) {
+        throw new Error(`invalid message: ${message}`);
+    }
+    if (
+        !/^[0-9a-fA-F]{1,64}$/.test(signature.r) ||
+        !/^[0-9a-fA-F]{1,64}$/.test(signature.s)
+    ) {
+        throw new Error(`invalid signature: ${signature}`);
+    }
+    if (!/^[0-9a-fA-F]{128}$/.test(pub)) {
+        throw new Error(`invalid public key: ${pub}`);
+    }
     const key = secp256k1.keyFromPublic("04" + pub, "hex");
     if (!key.validate().result) {
         return false;
@@ -109,6 +127,15 @@ export const recoverSchnorr = (
     message: string,
     signature: SchnorrSignature
 ): string => {
+    if (!/^[0-9a-fA-F]{64}$/.test(message)) {
+        throw new Error(`invalid message: ${message}`);
+    }
+    if (
+        !/^[0-9a-fA-F]{1,64}$/.test(signature.r) ||
+        !/^[0-9a-fA-F]{1,64}$/.test(signature.s)
+    ) {
+        throw new Error(`invalid signature: ${signature}`);
+    }
     const r = new BN(signature.r, 16);
     const s = new BN(signature.s, 16);
     if (s.gte(secp256k1.n)) {

--- a/test/key.test.ts
+++ b/test/key.test.ts
@@ -22,7 +22,8 @@ test("getPublicFromPrivate", () => {
 });
 
 test("sign & verify ECDSA", () => {
-    const msg = "CodeChain";
+    const msg =
+        "0000000000000000000000000000000000000000000000000000000000000000";
     const priv = generatePrivateKey();
     const pub = getPublicFromPrivate(priv);
     const sig = signEcdsa(msg, priv);
@@ -30,7 +31,8 @@ test("sign & verify ECDSA", () => {
 });
 
 test("sign & recover ECDSA", () => {
-    const msg = "CodeChain";
+    const msg =
+        "0000000000000000000000000000000000000000000000000000000000000000";
     const priv = generatePrivateKey();
     const pub = getPublicFromPrivate(priv);
     const sig = signEcdsa(msg, priv);
@@ -64,8 +66,7 @@ describe.each([
         "353d8f4a3d139a57bdf9b1c3a836f3a380fe8ba558356cd344766c97990b923b",
         "74cb307814a2f43ed0974dc278d6fc42f04c9d682e2df6a4a449bf628c4a3a03bbf6558b4c4a8e4148322cff3b2ce11eb96b0a9c76395054550ba307eed98573"
     ]
-])("verify & recover Schnorr with example: %p", (msgStr, priv, sigStr) => {
-    const msg = new Buffer(msgStr, "hex").toString("binary");
+])("verify & recover Schnorr with example: %p", (msg, priv, sigStr) => {
     const sig: SchnorrSignature = {
         r: sigStr.substr(0, 64),
         s: sigStr.substr(64, 64)
@@ -81,7 +82,8 @@ describe.each([
 });
 
 test("sign & verify Schnorr", () => {
-    const msg = "CodeChain";
+    const msg =
+        "0000000000000000000000000000000000000000000000000000000000000000";
     const priv = generatePrivateKey();
     const pub = getPublicFromPrivate(priv);
     const sig = signSchnorr(msg, priv);
@@ -89,7 +91,8 @@ test("sign & verify Schnorr", () => {
 });
 
 test("sign & recover Schnorr", () => {
-    const msg = "CodeChain";
+    const msg =
+        "0000000000000000000000000000000000000000000000000000000000000000";
     const priv = generatePrivateKey();
     const pub = getPublicFromPrivate(priv);
     const sig = signSchnorr(msg, priv);


### PR DESCRIPTION
This patch is for checking hex-string inputs of the signature functions(both ECDSA and Schnorr), because both Elliptic and bn.js does not check inputs, and they convert a string input to integer in a wrong way.
The Schnorr signature functions get a message as a general string, not a hex string, so there's no check routine for that.