### PR TITLE
Fix a bug in fromBytes() of U64, U128, U256

### DIFF
--- a/src/value/U128.ts
+++ b/src/value/U128.ts
@@ -67,7 +67,11 @@ export class U128 {
 
     public static fromBytes(buffer: Buffer): U128 {
         const bytes = Array.from(buffer.values());
-        const length = bytes.shift()! - 0x80;
+        const first = bytes.shift()!;
+        if (first < 0x80) {
+            return new U64(first);
+        }
+        const length = first - 0x80;
         if (bytes.length !== length) {
             throw Error(`Invalid RLP for U128: ${bytes}`);
         } else if (length > 16) {

--- a/src/value/U256.ts
+++ b/src/value/U256.ts
@@ -70,7 +70,11 @@ export class U256 {
 
     public static fromBytes(buffer: Buffer): U256 {
         const bytes = Array.from(buffer.values());
-        const length = bytes.shift()! - 0x80;
+        const first = bytes.shift()!;
+        if (first < 0x80) {
+            return new U64(first);
+        }
+        const length = first! - 0x80;
         if (bytes.length !== length) {
             throw Error(`Invalid RLP for U256: ${bytes}`);
         } else if (length > 32) {

--- a/src/value/U64.ts
+++ b/src/value/U64.ts
@@ -63,7 +63,11 @@ export class U64 {
 
     public static fromBytes(buffer: Buffer): U64 {
         const bytes = Array.from(buffer.values());
-        const length = bytes.shift()! - 0x80;
+        const first = bytes.shift()!;
+        if (first < 0x80) {
+            return new U64(first);
+        }
+        const length = first! - 0x80;
         if (bytes.length !== length) {
             throw Error(`Invalid RLP for U64: ${bytes}`);
         } else if (length > 8) {

--- a/test/Uxxx.test.ts
+++ b/test/Uxxx.test.ts
@@ -79,6 +79,10 @@ describe.each([[U64, "U64", 8], [U128, "U128", 16], [U256, "U256", 32]])(
             let a;
             a = new Uxxx(0);
             expect(Uxxx.fromBytes(a.rlpBytes())).toEqual(a);
+            a = new Uxxx(1);
+            expect(Uxxx.fromBytes(a.rlpBytes())).toEqual(a);
+            a = new Uxxx(0x79);
+            expect(Uxxx.fromBytes(a.rlpBytes())).toEqual(a);
             a = new Uxxx(255);
             expect(Uxxx.fromBytes(a.rlpBytes())).toEqual(a);
             a = new Uxxx(1000);


### PR DESCRIPTION
It resolves https://github.com/CodeChain-io/codechain-primitives-js/issues/61