### PR TITLE
Replace the ripemd160 package with the crypto-js package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/CodeChain-io/codechain-primitives-js#readme",
   "devDependencies": {
     "@types/bn.js": "^4.11.2",
+    "@types/crypto-js": "^3.1.43",
     "@types/jest": "^23.3.2",
     "@types/lodash": "^4.14.116",
     "@types/node": "^10.10.0",
@@ -54,11 +55,11 @@
     "blakejs": "^1.1.0",
     "bn.js": "^4.11.8",
     "buffer": "^5.2.1",
+    "crypto-js": "^3.1.9-1",
     "elliptic": "^6.4.1",
     "hmac-drbg": "^1.0.1",
     "lodash": "^4.17.11",
-    "ripemd160": "^2.0.2",
-    "rlp": "^2.1.0",
-    "node-forge": "^0.7.6"
+    "node-forge": "^0.7.6",
+    "rlp": "^2.1.0"
   }
 }

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,13 +1,11 @@
+import { enc, RIPEMD160 } from "crypto-js";
+
 import { toHex } from "./utility";
 
 /**
  * @hidden
  */
 const blake = require("blakejs");
-/**
- * @hidden
- */
-const ripemd = require("ripemd160");
 
 /**
  * Gets data's 256 bit blake hash.
@@ -114,5 +112,5 @@ export const ripemd160 = (data: Buffer | string): string => {
     if (!(data instanceof Buffer)) {
         data = Buffer.from(data, "hex");
     }
-    return new ripemd().update(data).digest("hex");
+    return RIPEMD160(enc.Hex.parse(data.toString("hex"))).toString();
 };


### PR DESCRIPTION
The ripemd160 package cannot be built in React Native projects because one of
its dependencies, hash-base, depends on Node starndard library.